### PR TITLE
sataserver: add sataserver support to the VMM

### DIFF
--- a/libsel4vmmplatsupport/CMakeLists.txt
+++ b/libsel4vmmplatsupport/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(
     sel4vm
     fdt
     fdtgen
+    satadrivers
     sel4_autoconf
     sel4vm_Config
     usbdrivers_Config

--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio.h
@@ -16,12 +16,15 @@
 
 /* Virtio device IDs  */
 #define VIRTIO_NET_PCI_DEVICE_ID        0x1000
+#define VIRTIO_BLOCK_PCI_DEVICE_ID      0x1001
 #define VIRTIO_CONSOLE_PCI_DEVICE_ID    0x1003
 
 /* Virtio subsystem device ids */
 #define VIRTIO_ID_NET                   1
+#define VIRTIO_ID_BLOCK                 2
 #define VIRTIO_ID_CONSOLE               3
 
 /* Virtio PCI device classes  */
 #define VIRTIO_PCI_CLASS_NET            0x020000
+#define VIRTIO_PCI_CLASS_BLOCK          0x010000
 #define VIRTIO_PCI_CLASS_CONSOLE        0x078000

--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_blk.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_blk.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sel4vm/guest_vm.h>
+
+#include <sel4vmmplatsupport/ioports.h>
+#include <sel4vmmplatsupport/drivers/pci.h>
+#include <sel4vmmplatsupport/drivers/virtio_pci_emul.h>
+
+typedef struct virtio_blk {
+    unsigned int iobase;
+    virtio_emul_t *emul;
+    struct disk_driver *emul_driver;
+    raw_diskiface_funcs_t emul_driver_funcs;
+    ps_io_ops_t ioops;
+} virtio_blk_t;
+
+virtio_blk_t *common_make_virtio_blk(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *ioport,
+                                     ioport_range_t ioport_range, ioport_type_t port_type,
+                                     unsigned int interrupt_pin, unsigned int interrupt_line,
+                                     raw_diskiface_funcs_t backend, bool emulate_bar_access);
+
+raw_diskiface_funcs_t virtio_blk_default_backend(void);

--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_pci_emul.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_pci_emul.h
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <platsupport/io.h>
 #include <ethdrivers/raw.h>
+#include <satadrivers/raw.h>
 #include <sel4vmmplatsupport/drivers/virtio_pci_console.h>
 #include <sel4vm/guest_vm.h>
 #include <ethdrivers/virtio/virtio_ring.h>
@@ -23,6 +24,7 @@
 typedef enum virtio_pci_devices {
     VIRTIO_NET,
     VIRTIO_CONSOLE,
+    VIRTIO_BLOCK,
 } virtio_pci_devices_t;
 
 typedef struct v_queue {
@@ -66,3 +68,5 @@ uint16_t ring_avail(virtio_emul_t *emul, struct vring *vring, uint16_t idx);
 void *net_virtio_emul_init(virtio_emul_t *emul, ps_io_ops_t io_ops, ethif_driver_init driver, void *config);
 
 void *console_virtio_emul_init(virtio_emul_t *emul, ps_io_ops_t io_ops, console_driver_init driver, void *config);
+
+void *block_virtio_emul_init(virtio_emul_t *emul, ps_io_ops_t io_ops, diskif_driver_init driver, void *config);

--- a/libsel4vmmplatsupport/src/drivers/virtio_blk.c
+++ b/libsel4vmmplatsupport/src/drivers/virtio_blk.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2021, Data61, CSIRO (ABN 41 687 119 230)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <platsupport/io.h>
+
+#include <sel4vmmplatsupport/drivers/virtio.h>
+#include <sel4vmmplatsupport/drivers/virtio_blk.h>
+
+#include <pci/helper.h>
+#include <sel4vmmplatsupport/drivers/pci_helper.h>
+
+#define QUEUE_SIZE 128
+
+static ps_io_ops_t ops;
+
+static int virtio_blk_io_in(void *cookie, unsigned int port_no, unsigned int size, unsigned int *result)
+{
+    virtio_blk_t *blk = (virtio_blk_t *)cookie;
+    unsigned int offset = port_no - blk->iobase;
+    unsigned int val;
+    int err = blk->emul->io_in(blk->emul, offset, size, &val);
+    if (err) {
+        return err;
+    }
+    *result = val;
+    return 0;
+}
+
+static int virtio_blk_io_out(void *cookie, unsigned int port_no, unsigned int size, unsigned int value)
+{
+    int ret;
+    virtio_blk_t *blk = (virtio_blk_t *)cookie;
+    unsigned int offset = port_no - blk->iobase;
+    ret = blk->emul->io_out(blk->emul, offset, size, value);
+    return ret;
+}
+
+static int emul_driver_init(struct disk_driver *driver, ps_io_ops_t io_ops, void *config)
+{
+    virtio_blk_t *blk = (virtio_blk_t *)config;
+    driver->disk_data = config;
+    driver->dma_alignment = sizeof(uintptr_t);
+    driver->i_fn = blk->emul_driver_funcs;
+    blk->emul_driver = driver;
+    return 0;
+}
+
+static void *malloc_dma_alloc(void *cookie, size_t size, int align, int cached, ps_mem_flags_t flags)
+{
+    assert(cached);
+    int error;
+    void *ret;
+    error = posix_memalign(&ret, align, size);
+    if (error) {
+        return NULL;
+    }
+    return ret;
+}
+
+static void malloc_dma_free(void *cookie, void *addr, size_t size)
+{
+    free(addr);
+}
+
+static uintptr_t malloc_dma_pin(void *cookie, void *addr, size_t size)
+{
+    return (uintptr_t)addr;
+}
+
+static void malloc_dma_unpin(void *cookie, void *addr, size_t size)
+{
+    ZF_LOGF("not implemented");
+}
+
+static void malloc_dma_cache_op(void *cookie, void *addr, size_t size, dma_cache_op_t op)
+{
+    ZF_LOGF("not implemented");
+}
+
+static vmm_pci_entry_t vmm_virtio_blk_pci_bar(unsigned int iobase, size_t iobase_size_bits,
+                                              unsigned int interrupt_pin, unsigned int interrupt_line,
+                                              bool emulate_bar_access)
+{
+    vmm_pci_device_def_t *pci_config;
+    int err = ps_calloc(&ops.malloc_ops, 1, sizeof(*pci_config), (void **) &pci_config);
+    ZF_LOGF_IF(err, "Failed to allocate pci_config");
+    *pci_config = (vmm_pci_device_def_t) {
+        .vendor_id = VIRTIO_PCI_VENDOR_ID,
+        .device_id = VIRTIO_BLOCK_PCI_DEVICE_ID,
+        .command = PCI_COMMAND_IO,
+        .header_type = PCI_HEADER_TYPE_NORMAL,
+        .subsystem_vendor_id = VIRTIO_PCI_SUBSYSTEM_VENDOR_ID,
+        .subsystem_id = VIRTIO_ID_BLOCK,
+        .interrupt_pin = interrupt_pin,
+        .interrupt_line = interrupt_line,
+        .bar0 = iobase | PCI_BASE_ADDRESS_SPACE_IO,
+        .cache_line_size = 64,
+        .latency_timer = 64,
+        .prog_if = VIRTIO_PCI_CLASS_BLOCK & 0xff,
+        .subclass = (VIRTIO_PCI_CLASS_BLOCK >> 8) & 0xff,
+        .class_code = (VIRTIO_PCI_CLASS_BLOCK >> 16) & 0xff,
+    };
+    vmm_pci_entry_t entry = (vmm_pci_entry_t) {
+        .cookie = pci_config,
+        .ioread = vmm_pci_mem_device_read,
+        .iowrite = vmm_pci_entry_ignore_write
+    };
+
+    vmm_pci_bar_t bars[1] = {{
+            .mem_type = NON_MEM,
+            .address = iobase,
+            .size_bits = iobase_size_bits
+        }
+    };
+    vmm_pci_entry_t virtio_pci_bar;
+    if (emulate_bar_access) {
+        virtio_pci_bar = vmm_pci_create_bar_emulation(entry, 1, bars);
+    } else {
+        virtio_pci_bar = vmm_pci_create_passthrough_bar_emulation(entry, 1, bars);
+    }
+    return virtio_pci_bar;
+}
+
+virtio_blk_t *common_make_virtio_blk(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *ioport,
+                                     ioport_range_t ioport_range, ioport_type_t port_type,
+                                     unsigned int interrupt_pin, unsigned int interrupt_line,
+                                     raw_diskiface_funcs_t backend, bool emulate_bar_access)
+{
+    int err = ps_new_stdlib_malloc_ops(&ops.malloc_ops);
+    ZF_LOGF_IF(err, "Failed to get malloc ops");
+
+    virtio_blk_t *blk;
+    err = ps_calloc(&ops.malloc_ops, 1, sizeof(*blk), (void **)&blk);
+    ZF_LOGF_IF(err, "Failed to allocate virtio blk");
+
+    ioport_interface_t virtio_io_interface = {blk, virtio_blk_io_in, virtio_blk_io_out, "VIRTIO PCI BLK"};
+    ioport_entry_t *io_entry = vmm_io_port_add_handler(ioport, ioport_range, virtio_io_interface, port_type);
+    if (!io_entry) {
+        ZF_LOGE("Failed to add vmm io port handler");
+        return NULL;
+    }
+
+    size_t iobase_size_bits = BYTES_TO_SIZE_BITS(io_entry->range.size);
+    blk->iobase = io_entry->range.start;
+    ZF_LOGE("iobase_size_bits = %zu", iobase_size_bits);
+
+    vmm_pci_entry_t entry = vmm_virtio_blk_pci_bar(io_entry->range.start, iobase_size_bits,
+                                                   interrupt_pin, interrupt_line,
+                                                   emulate_bar_access);
+    vmm_pci_add_entry(pci, entry, NULL);
+
+    ps_io_ops_t ioops;
+    ioops.dma_manager = (ps_dma_man_t) {
+        .cookie = NULL,
+        .dma_alloc_fn = malloc_dma_alloc,
+        .dma_free_fn = malloc_dma_free,
+        .dma_pin_fn = malloc_dma_pin,
+        .dma_unpin_fn = malloc_dma_unpin,
+        .dma_cache_op_fn = malloc_dma_cache_op
+    };
+
+    blk->emul_driver_funcs = backend;
+    blk->emul = virtio_emul_init(ioops, QUEUE_SIZE, vm, emul_driver_init, blk, VIRTIO_BLOCK);
+
+    assert(blk->emul);
+    return blk;
+}
+
+static int emul_raw_xfer(struct disk_driver *driver, uint8_t direction, uint64_t sector, uint32_t len,
+                         uintptr_t guest_buf_phys)
+{
+    ZF_LOGF("not implemented");
+}
+
+static void emul_raw_handle_irq(struct disk_driver *driver, int irq)
+{
+    ZF_LOGF("not implemented");
+}
+
+static void emul_raw_poll(struct disk_driver *driver)
+{
+    ZF_LOGF("not implemented");
+}
+
+static void emul_low_level_init(struct disk_driver *driver, struct virtio_blk_config *cfg)
+{
+    ZF_LOGF("not implemented");
+}
+
+static void emul_print_state(struct disk_driver *driver)
+{
+    ZF_LOGF("not implemented");
+}
+
+static raw_diskiface_funcs_t emul_driver_funcs = {
+    .raw_xfer = emul_raw_xfer,
+    .raw_handleIRQ = emul_raw_handle_irq,
+    .raw_poll = emul_raw_poll,
+    .print_state = emul_print_state,
+    .low_level_init = emul_low_level_init
+};
+
+raw_diskiface_funcs_t virtio_blk_default_backend(void)
+{
+    return emul_driver_funcs;
+}

--- a/libsel4vmmplatsupport/src/drivers/virtio_block_emul.c
+++ b/libsel4vmmplatsupport/src/drivers/virtio_block_emul.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2019, Dornerworks
+ *
+ * SPDX-License-Identifier: GPL-2.0-only
+ */
+
+#include <sel4vmmplatsupport/drivers/virtio_pci_emul.h>
+#include <stdbool.h>
+
+#include "virtio_emul_helpers.h"
+
+#define BUF_SIZE 8192
+#define MAX_DATA_BUF_SIZE 4096
+
+#define NUM_REQUEST_ADDRS 3
+
+typedef struct blkif_virtio_emul_internal {
+    struct disk_driver driver;
+    struct virtio_blk_config cfg;
+    ps_dma_man_t dma_man;
+} blkif_virtio_emul_internal_t;
+
+typedef struct emul_tx_cookie {
+    uint16_t desc_head;
+    void *vaddr;
+} emul_tx_cookie_t;
+
+static void complete_virtio_blk_request(void *iface, void *cookie)
+{
+    virtio_emul_t *emul = (virtio_emul_t *) iface;
+    blkif_virtio_emul_internal_t *blk = emul->internal;
+    emul_tx_cookie_t *tx_cookie = (emul_tx_cookie_t *)cookie;
+    /* free the dma memory */
+    ps_dma_unpin(&blk->dma_man, tx_cookie->vaddr, BUF_SIZE);
+    ps_dma_free(&blk->dma_man, tx_cookie->vaddr, BUF_SIZE);
+    /* put the descriptor chain into the used list */
+    struct vring_used_elem used_elem = {tx_cookie->desc_head, 0};
+    ring_used_add(emul, &emul->virtq.vring[emul->virtq.queue], used_elem);
+    free(tx_cookie);
+    /* notify the guest that we have completed some of its buffers */
+    blk->driver.i_fn.raw_handleIRQ(&blk->driver, 0);
+}
+
+static void handle_virtio_blk_request(virtio_emul_t *emul)
+{
+    /* Create Local Copies of the Passed in Structure */
+    blkif_virtio_emul_internal_t *blk = (blkif_virtio_emul_internal_t *) emul->internal;
+    struct vring *vring = &emul->virtq.vring[emul->virtq.queue];
+
+    /* read the index */
+    uint16_t guest_idx = ring_avail_idx(emul, vring);
+
+    /* process what we can of the ring */
+    uint16_t idx = emul->virtq.last_idx[emul->virtq.queue];
+    uint32_t buf_len = 0;
+
+    uint64_t desc_addrs[NUM_REQUEST_ADDRS];
+
+    while (idx != guest_idx) {
+        uint16_t desc_head;
+
+        /* read the head of the descriptor chain */
+        desc_head = ring_avail(emul, vring, idx);
+
+        /* allocate a packet */
+        void *vaddr = ps_dma_alloc(&blk->dma_man, BUF_SIZE, blk->driver.dma_alignment, 1, PS_MEM_NORMAL);
+        if (!vaddr) {
+            /* try again later */
+            break;
+        }
+        uintptr_t phys = ps_dma_pin(&blk->dma_man, vaddr, BUF_SIZE);
+        assert(phys);
+
+        /* length of the final packet to deliver */
+        uint32_t len = 0;
+
+        /* start walking the descriptors */
+        struct vring_desc desc;
+        uint16_t desc_idx = desc_head;
+        int i = 0;
+        do {
+            desc = ring_desc(emul, vring, desc_idx);
+            /* truncate packets that are too large */
+            uint32_t this_len = MIN(BUF_SIZE - len, desc.len);
+            vm_guest_read_mem(emul->vm, vaddr + len, (uintptr_t) desc.addr, this_len);
+            /* Save off the descriptor addresses so we can write back to the VM */
+            desc_addrs[i] = desc.addr;
+            /* The second descriptor (index 1) is the data buffer.
+             *  The length of this buffer determines how much we need to
+             *  copy to or from this buffer.
+             */
+            if (i == 1) {
+                buf_len = desc.len;
+            }
+            i++;
+            len += this_len;
+            desc_idx = desc.next;
+        } while (desc.flags & VRING_DESC_F_NEXT);
+        /* ship it */
+        emul_tx_cookie_t *cookie = calloc(1, sizeof(*cookie));
+        assert(cookie);
+        cookie->desc_head = desc_head;
+        cookie->vaddr = vaddr;
+
+        /* Currently we can only handle buffers of a certain size or less.
+         *  We could fix this, but not sure if it is necessary based on the
+         *  FileSystem types that have been tested
+         */
+        assert(buf_len <= MAX_DATA_BUF_SIZE);
+
+        struct virtio_blk_outhdr hdr;
+        memcpy(&hdr, vaddr, sizeof(struct virtio_blk_outhdr));
+
+        /* Calculate the addresses to which we actually write data */
+        void *guest_buf_start = vaddr + sizeof(struct virtio_blk_outhdr);
+        void *req_status_start = vaddr + sizeof(struct virtio_blk_outhdr) + buf_len;
+
+        /* Start disk read or write chain */
+        int result = blk->driver.i_fn.raw_xfer(&blk->driver, hdr.type, hdr.sector, buf_len, (uintptr_t) guest_buf_start);
+
+        switch (result) {
+        case VIRTIO_BLK_XFER_COMPLETE:
+            *(uint8_t *)req_status_start = VIRTIO_BLK_S_OK;
+            if (VIRTIO_BLK_T_IN == hdr.type) {
+                /* We assume descriptor address at index 1 is the buffer */
+                vm_guest_write_mem(emul->vm, vaddr + sizeof(struct virtio_blk_outhdr), desc_addrs[1], buf_len);
+            }
+            /* We assume descriptor address at index 2 is the status of the IO cmd*/
+            vm_guest_write_mem(emul->vm, vaddr + sizeof(struct virtio_blk_outhdr) + buf_len, desc_addrs[2], 1);
+            complete_virtio_blk_request(emul, cookie);
+            break;
+        case VIRTIO_BLK_XFER_FAILED:
+            *(uint8_t *)req_status_start = VIRTIO_BLK_S_IOERR;
+            vm_guest_write_mem(emul->vm, vaddr + sizeof(struct virtio_blk_outhdr) + buf_len, desc_addrs[2], 1);
+            complete_virtio_blk_request(emul, cookie);
+            break;
+        }
+        /* next */
+        idx++;
+    }
+    /* update which parts of the ring we have processed */
+    emul->virtq.last_idx[emul->virtq.queue] = idx;
+}
+
+static bool emul_io_in(struct virtio_emul *emul, unsigned int offset, unsigned int size, unsigned int *result)
+{
+    bool handled = false;
+    blkif_virtio_emul_internal_t *blkif_internal = emul->internal;
+    switch (offset) {
+    case VIRTIO_PCI_HOST_FEATURES:
+        handled = true;
+        assert(size == 4);
+        *result = (BIT(VIRTIO_BLK_F_BLK_SIZE) | BIT(VIRTIO_BLK_F_SEG_MAX) | BIT(VIRTIO_BLK_F_SIZE_MAX));
+        break;
+    case VIRTIO_PCI_CONFIG_OFF(0) ... VIRTIO_PCI_CONFIG_OFF(0) + sizeof(struct virtio_blk_config):
+        handled = true;
+        assert(size == 1);
+        memcpy(result, (((uint8_t *)&blkif_internal->cfg) + offset - VIRTIO_PCI_CONFIG_OFF(0)), size);
+        break;
+    }
+    return handled;
+}
+
+static bool emul_io_out(struct virtio_emul *emul, unsigned int offset, unsigned int size, unsigned int value)
+{
+    bool handled = false;
+    blkif_virtio_emul_internal_t *blkif_internal = emul->internal;
+    switch (offset) {
+    case VIRTIO_PCI_GUEST_FEATURES:
+        handled = true;
+        assert(size == 4);
+        /* Guest can support a subset of these features */
+        assert(value & (BIT(VIRTIO_BLK_F_BLK_SIZE) | BIT(VIRTIO_BLK_F_SEG_MAX) | BIT(VIRTIO_BLK_F_SIZE_MAX)));
+        break;
+    case VIRTIO_PCI_QUEUE_NOTIFY:
+        handled = true;
+        handle_virtio_blk_request(emul);
+    }
+    return handled;
+}
+
+static void emul_notify(virtio_emul_t *emul)
+{
+    if (emul->virtq.status != VIRTIO_CONFIG_S_DRIVER_OK) {
+        return;
+    }
+    handle_virtio_blk_request(emul);
+}
+
+void *block_virtio_emul_init(virtio_emul_t *emul, ps_io_ops_t io_ops, diskif_driver_init driver, void *config)
+{
+    blkif_virtio_emul_internal_t *internal = NULL;
+
+    int err;
+    internal = calloc(1, sizeof(*internal));
+    if (!emul || !internal) {
+        goto error;
+    }
+    emul->device_io_in = emul_io_in;
+    emul->device_io_out = emul_io_out;
+    emul->notify = emul_notify;
+    internal->driver.cb_cookie = emul;
+    internal->dma_man = io_ops.dma_manager;
+    err = driver(&internal->driver, io_ops, config);
+    if (err) {
+        ZF_LOGE("Fafiled to initialize driver");
+        goto error;
+    }
+    internal->driver.i_fn.low_level_init(&internal->driver, &internal->cfg);
+    return (void *)internal;
+error:
+    if (internal) {
+        free(internal);
+    }
+    return NULL;
+}

--- a/libsel4vmmplatsupport/src/drivers/virtio_emul.c
+++ b/libsel4vmmplatsupport/src/drivers/virtio_emul.c
@@ -123,6 +123,9 @@ virtio_emul_t *virtio_emul_init(ps_io_ops_t io_ops, int queue_size, vm_t *vm, vo
     case VIRTIO_NET:
         emul->internal = net_virtio_emul_init(emul, io_ops, (ethif_driver_init)driver, config);
         break;
+    case VIRTIO_BLOCK:
+        emul->internal = block_virtio_emul_init(emul, io_ops, (diskif_driver_init)driver, config);
+        break;
     }
     if (emul->internal == NULL) {
         return NULL;
@@ -132,7 +135,7 @@ virtio_emul_t *virtio_emul_init(ps_io_ops_t io_ops, int queue_size, vm_t *vm, vo
     emul->virtq.queue_size[TX_QUEUE] = queue_size;
     /* create dummy rings. we never actually dereference the rings so they can be null */
     vring_init(&emul->virtq.vring[RX_QUEUE], emul->virtq.queue_size[RX_QUEUE], 0, VIRTIO_PCI_VRING_ALIGN);
-    vring_init(&emul->virtq.vring[TX_QUEUE], emul->virtq.queue_size[RX_QUEUE], 0, VIRTIO_PCI_VRING_ALIGN);
+    vring_init(&emul->virtq.vring[TX_QUEUE], emul->virtq.queue_size[TX_QUEUE], 0, VIRTIO_PCI_VRING_ALIGN);
     emul->io_in = emul_io_in;
     emul->io_out = emul_io_out;
 


### PR DESCRIPTION
Virtio-blk and sataserver components PR to our fork.
There is currently an open PR to upstream as well, but it hasn't been merged yet.
See https://github.com/seL4/seL4_projects_libs/pull/17

This commit combines a number of commits which do the following:
    * Add virtio blk support to vmm
    * Link satadrivers into vmm library so VMM can use virtio-blk
    * Enable size max feature to virtio blk requests
    * Refactor virtio blk code in libsel4vmm
    * Cast values to avoid compiler warnings

CCDC-GVSC DISTRIBUTION A.  Approved for public release; distribution
unlimited. OPSEC#4481.

Co-authored-by: Chris Guikema <chris.guikema@dornerworks.com>
Co-authored-by: Alex Pavey <Alex.Pavey@Dornerworks.com>
Signed-off-by: Damon Lee <Damon.Lee@data61.csiro.au>