### PR TITLE
libsel4vmmplatsupport: fix PCI passthrough on ARM

### DIFF
--- a/libsel4vmmplatsupport/arch_include/arm/sel4vmmplatsupport/arch/vpci.h
+++ b/libsel4vmmplatsupport/arch_include/arm/sel4vmmplatsupport/arch/vpci.h
@@ -36,6 +36,9 @@ int vm_install_vpci(vm_t *vm, vmm_io_port_list_t *io_port, vmm_pci_space_t *pci)
  * @param {vmm_pci_space_t *}       PCI library instance to generate fdt node
  * @param {void *} fdt              FDT blob to append generated device node
  * @param {int} gic_phandle         Phandle of IRQ controller to generate a correct interrupt map property
+ * @param {int} interrupt_pin       Interrupt pin used for all devices
+ * @param {int} interrupt_line      Interrupt line used for all devices
  * @return                          0 for success, -1 for error
  */
-int fdt_generate_vpci_node(vm_t *vm, vmm_pci_space_t *pci, void *fdt, int gic_phandle);
+int fdt_generate_vpci_node(vm_t *vm, vmm_pci_space_t *pci, void *fdt, int gic_phandle,
+                           int interrupt_pin, int interrupt_line);

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_vpci.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_vpci.md
@@ -17,7 +17,7 @@ virtual pci device.
 
 > [`vm_install_vpci(vm, io_port, pci)`](#function-vm_install_vpcivm-io_port-pci)
 
-> [`fdt_generate_vpci_node(vm, pci, fdt, gic_phandle)`](#function-fdt_generate_vpci_nodevm-pci-fdt-gic_phandle)
+> [`fdt_generate_vpci_node(vm, pci, fdt, gic_phandle, interrupt_pin, interrupt_line)`](#function-fdt_generate_vpci_nodevm-pci-fdt-gic_phandle-interrupt_pin-interrupt_line)
 
 
 ## Functions
@@ -40,10 +40,11 @@ The interface `vpci.h` defines the following functions.
 
 Back to [interface description](#module-vpcih).
 
-### Function `fdt_generate_vpci_node(vm, pci, fdt, gic_phandle)`
+### Function `fdt_generate_vpci_node(vm, pci, fdt, gic_phandle, interrupt_pin, interrupt_line)`
 
 Generate a PCI device node for a given fdt. This taking into account
-the virtual PCI device configuration space.
+the virtual PCI device configuration space. Note that currently both the same interrupt pin and
+line are used for all the devices in the PCI bus. For virtio devices this suffices for now.
 
 **Parameters:**
 
@@ -51,6 +52,8 @@ the virtual PCI device configuration space.
 - `PCI {vmm_pci_space_t *}`: library instance to generate fdt node
 - `fdt {void *}`: FDT blob to append generated device node
 - `gic_phandle {int}`: Phandle of IRQ controller to generate a correct interrupt map property
+- `interrupt_pin {int}`: Interrupt pin used for all devices
+- `interrupt_line {int}`: Interrupt line used for all devices
 
 **Returns:**
 

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_pci_helper.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_pci_helper.md
@@ -25,8 +25,6 @@ the creation of pci device entries and accessors the their configuration spaces.
 
 > [`vmm_pci_create_bar_emulation(existing, num_bars, bars)`](#function-vmm_pci_create_bar_emulationexisting-num_bars-bars)
 
-> [`vmm_pci_create_passthrough_bar_emulation(existing, num_bars, bars)`](#function-vmm_pci_create_passthrough_bar_emulationexisting-num_bars-bars)
-
 > [`vmm_pci_create_irq_emulation(existing, irq)`](#function-vmm_pci_create_irq_emulationexisting-irq)
 
 > [`vmm_pci_create_cap_emulation(existing, num_caps, cap, num_ranges, range_starts, range_ends)`](#function-vmm_pci_create_cap_emulationexisting-num_caps-cap-num_ranges-range_starts-range_ends)
@@ -146,23 +144,6 @@ Construct a pci entry that emulates configuration space bar read/write's. The re
 **Returns:**
 
 - `vmm_pci_entry_t` for emulated bar device
-
-Back to [interface description](#module-pcih).
-
-### Function `vmm_pci_create_passthrough_bar_emulation(existing, num_bars, bars)`
-
-Construct a pci entry that passes through all bar read/writes through to emulated io(read/write) handlers. This is the
-inverse of `vmm_pci_create_bar_emulation`
-
-**Parameters:**
-
-- `existing {vmm_pci_entry_t}`: Existing PCI entry to wrap over and passthrough bar read/writes
-- `num_bars {int}`: Number of emulated bars in PCI entry
-- `bars {vmm_pci_bar_t *}`: Set of bars to passthrough access to
-
-**Returns:**
-
-- `vmm_pci_entry_t` for passthrough bar device
 
 Back to [interface description](#module-pcih).
 

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_virtio_net.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_virtio_net.md
@@ -14,7 +14,7 @@ guest.
 
 **Functions**:
 
-> [`common_make_virtio_net(vm, pci, ioport, ioport_range, port_type, interrupt_pin, interrupt_line, backend, emulate_bar_access)`](#function-common_make_virtio_netvm-pci-ioport-ioport_range-port_type-interrupt_pin-interrupt_line-backend-emulate_bar_access)
+> [`common_make_virtio_net(vm, pci, ioport, ioport_range, port_type, interrupt_pin, interrupt_line, backend)`](#function-common_make_virtio_netvm-pci-ioport-ioport_range-port_type-interrupt_pin-interrupt_line-backend)
 
 > [`virtio_net_default_backend()`](#function-virtio_net_default_backend)
 
@@ -29,7 +29,7 @@ guest.
 
 The interface `virtio_net.h` defines the following functions.
 
-### Function `common_make_virtio_net(vm, pci, ioport, ioport_range, port_type, interrupt_pin, interrupt_line, backend, emulate_bar_access)`
+### Function `common_make_virtio_net(vm, pci, ioport, ioport_range, port_type, interrupt_pin, interrupt_line, backend)`
 
 Initialise a new virtio_net device with Base Address Registers (BARs) starting at iobase and backend functions
 specified by the raw_iface_funcs struct.
@@ -45,7 +45,6 @@ virtio_net_default_backend for default methods.
 - `interrupt_pin {unsigned int}`: PCI interrupt pin e.g. INTA = 1, INTB = 2 ,...
 - `interrupt_line {unsigned int}`: PCI interrupt line for virtio net IRQS
 - `backend {struct raw_iface_funcs}`: Function pointers to backend implementation. Can be initialised by
-- `emulate_bar {bool}`: Emulate read and writes accesses to the PCI device Base Address Registers.
 
 **Returns:**
 

--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/pci_helper.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/pci_helper.h
@@ -235,17 +235,6 @@ vmm_pci_entry_t vmm_pci_create_passthrough(vmm_pci_address_t addr, vmm_pci_confi
 vmm_pci_entry_t vmm_pci_create_bar_emulation(vmm_pci_entry_t existing, int num_bars, vmm_pci_bar_t *bars);
 
 /***
- * @function vmm_pci_create_passthrough_bar_emulation(existing, num_bars, bars)
- * Construct a pci entry that passes through all bar read/writes through to emulated io(read/write) handlers. This is the
- * inverse of `vmm_pci_create_bar_emulation`
- * @param {vmm_pci_entry_t} existing    Existing PCI entry to wrap over and passthrough bar read/writes
- * @param {int} num_bars                Number of emulated bars in PCI entry
- * @param {vmm_pci_bar_t *} bars        Set of bars to passthrough access to
- * @return                               `vmm_pci_entry_t` for passthrough bar device
- */
-vmm_pci_entry_t vmm_pci_create_passthrough_bar_emulation(vmm_pci_entry_t existing, int num_bars, vmm_pci_bar_t *bars);
-
-/***
  * @function vmm_pci_create_irq_emulation(existing, irq)
  * Construct a pci entry the emulates configuration space interrupt read/write's. The rest of the configuration space is passed on
  * @param {vmm_pci_entry_t} existing    Existing PCI entry to wrap over and emulate its IRQ accesses

--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_net.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_net.h
@@ -37,7 +37,7 @@ typedef struct virtio_net {
 } virtio_net_t;
 
 /***
- * @function common_make_virtio_net(vm, pci, ioport, ioport_range, port_type, interrupt_pin, interrupt_line, backend, emulate_bar_access)
+ * @function common_make_virtio_net(vm, pci, ioport, ioport_range, port_type, interrupt_pin, interrupt_line, backend)
  * Initialise a new virtio_net device with Base Address Registers (BARs) starting at iobase and backend functions
  * specified by the raw_iface_funcs struct.
  * @param {vm_t *} vm                       A handle to the VM
@@ -49,12 +49,11 @@ typedef struct virtio_net {
  * @param {unsigned int} interrupt_line     PCI interrupt line for virtio net IRQS
  * @param {struct raw_iface_funcs} backend  Function pointers to backend implementation. Can be initialised by
  *                                          virtio_net_default_backend for default methods.
- * @param {bool} emulate_bar                Emulate read and writes accesses to the PCI device Base Address Registers.
  * @return                                  Pointer to an initialised virtio_net_t, NULL if error.
  */
 virtio_net_t *common_make_virtio_net(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *ioport,
                                      ioport_range_t ioport_range, ioport_type_t port_type, unsigned int interrupt_pin, unsigned int interrupt_line,
-                                     struct raw_iface_funcs backend, bool emulate_bar_access);
+                                     struct raw_iface_funcs backend);
 
 /***
  * @function virtio_net_default_backend()

--- a/libsel4vmmplatsupport/src/drivers/cross_vm_connection.c
+++ b/libsel4vmmplatsupport/src/drivers/cross_vm_connection.c
@@ -95,12 +95,7 @@ static int construct_connection_bar(vm_t *vm, struct connection_info *info, int 
             }
         };
         vmm_pci_entry_t connection_pci_bar;
-        /* TODO: Make both architecture go through the same interface */
-        if (config_set(CONFIG_ARCH_X86)) {
-            connection_pci_bar = vmm_pci_create_bar_emulation(entry, 2, bars);
-        } else if (config_set(CONFIG_ARCH_ARM)) {
-            connection_pci_bar = vmm_pci_create_passthrough_bar_emulation(entry, 2, bars);
-        }
+        connection_pci_bar = vmm_pci_create_bar_emulation(entry, 2, bars);
         vmm_pci_add_entry(pci, connection_pci_bar, NULL);
     }
     return 0;

--- a/libsel4vmmplatsupport/src/drivers/pci_helper.c
+++ b/libsel4vmmplatsupport/src/drivers/pci_helper.c
@@ -230,18 +230,6 @@ static int pci_bar_emul_write(void *cookie, int offset, int size, uint32_t value
     return 0;
 }
 
-static int pci_bar_passthrough_emul_read(void *cookie, int offset, int size, uint32_t *result)
-{
-    pci_bar_emulation_t *emul = (pci_bar_emulation_t *)cookie;
-    return emul->passthrough.ioread(emul->passthrough.cookie, offset, size, result);
-}
-
-static int pci_bar_passthrough_emul_write(void *cookie, int offset, int size, uint32_t value)
-{
-    pci_bar_emulation_t *emul = (pci_bar_emulation_t *)cookie;
-    return emul->passthrough.iowrite(emul->passthrough.cookie, offset, size, value);
-}
-
 vmm_pci_entry_t vmm_pci_create_bar_emulation(vmm_pci_entry_t existing, int num_bars, vmm_pci_bar_t *bars)
 {
     pci_bar_emulation_t *bar_emul = calloc(1, sizeof(*bar_emul));
@@ -252,19 +240,6 @@ vmm_pci_entry_t vmm_pci_create_bar_emulation(vmm_pci_entry_t existing, int num_b
     memset(bar_emul->bar_writes, 0, sizeof(bar_emul->bar_writes));
     return (vmm_pci_entry_t) {
         .cookie = bar_emul, .ioread = pci_bar_emul_read, .iowrite = pci_bar_emul_write
-    };
-}
-
-vmm_pci_entry_t vmm_pci_create_passthrough_bar_emulation(vmm_pci_entry_t existing, int num_bars, vmm_pci_bar_t *bars)
-{
-    pci_bar_emulation_t *bar_emul = calloc(1, sizeof(*bar_emul));
-    assert(bar_emul);
-    memcpy(bar_emul->bars, bars, sizeof(vmm_pci_bar_t) * num_bars);
-    bar_emul->passthrough = existing;
-    bar_emul->num_bars = num_bars;
-    memset(bar_emul->bar_writes, 0, sizeof(bar_emul->bar_writes));
-    return (vmm_pci_entry_t) {
-        .cookie = bar_emul, .ioread = pci_bar_passthrough_emul_read, .iowrite = pci_bar_passthrough_emul_write
     };
 }
 

--- a/libsel4vmmplatsupport/src/drivers/virtio_con.c
+++ b/libsel4vmmplatsupport/src/drivers/virtio_con.c
@@ -83,7 +83,7 @@ static vmm_pci_entry_t vmm_virtio_console_pci_bar(unsigned int iobase,
             .size_bits = iobase_size_bits
         }
     };
-    return vmm_pci_create_passthrough_bar_emulation(entry, 1, bars);
+    return vmm_pci_create_bar_emulation(entry, 1, bars);
 }
 
 virtio_con_t *common_make_virtio_con(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *ioport,

--- a/libsel4vmmplatsupport/src/drivers/virtio_net.c
+++ b/libsel4vmmplatsupport/src/drivers/virtio_net.c
@@ -123,7 +123,7 @@ struct raw_iface_funcs virtio_net_default_backend()
 
 static vmm_pci_entry_t vmm_virtio_net_pci_bar(unsigned int iobase,
                                               size_t iobase_size_bits, unsigned int interrupt_pin,
-                                              unsigned int interrupt_line, bool emulate_bar_access)
+                                              unsigned int interrupt_line)
 {
     vmm_pci_device_def_t *pci_config;
     int err = ps_calloc(&ops.malloc_ops, 1, sizeof(*pci_config), (void **)&pci_config);
@@ -156,18 +156,12 @@ static vmm_pci_entry_t vmm_virtio_net_pci_bar(unsigned int iobase,
             .size_bits = iobase_size_bits
         }
     };
-    vmm_pci_entry_t virtio_pci_bar;
-    if (emulate_bar_access) {
-        virtio_pci_bar = vmm_pci_create_bar_emulation(entry, 1, bars);
-    } else {
-        virtio_pci_bar = vmm_pci_create_passthrough_bar_emulation(entry, 1, bars);
-    }
-    return virtio_pci_bar;
+    return vmm_pci_create_bar_emulation(entry, 1, bars);
 }
 
 virtio_net_t *common_make_virtio_net(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *ioport,
                                      ioport_range_t ioport_range, ioport_type_t port_type, unsigned int interrupt_pin, unsigned int interrupt_line,
-                                     struct raw_iface_funcs backend, bool emulate_bar_access)
+                                     struct raw_iface_funcs backend)
 {
     int err = ps_new_stdlib_malloc_ops(&ops.malloc_ops);
     ZF_LOGF_IF(err, "Failed to get malloc ops");
@@ -186,8 +180,7 @@ virtio_net_t *common_make_virtio_net(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port
     size_t iobase_size_bits = BYTES_TO_SIZE_BITS(io_entry->range.size);
     net->iobase = io_entry->range.start;
 
-    vmm_pci_entry_t entry = vmm_virtio_net_pci_bar(io_entry->range.start, iobase_size_bits, interrupt_pin, interrupt_line,
-                                                   emulate_bar_access);
+    vmm_pci_entry_t entry = vmm_virtio_net_pci_bar(io_entry->range.start, iobase_size_bits, interrupt_pin, interrupt_line);
     vmm_pci_add_entry(pci, entry, NULL);
 
     ps_io_ops_t ioops;


### PR DESCRIPTION
BAR size resolution was emulated in two places, the fault handler and
the backend created with vmm_pci_create_passthrough_bar_emulation().
Move to vmm_pci_create_bar_emulation() on ARM VM as well, and remove
the former. This way there is no need for BAR hack in the fault handler
and the backend created with vmm_pci_create_passthrough() works now on
ARM.

Also fixes the write size of the PCI fault handler, as it was discarded
previously and fixed size of 32 bits was always used.

As a side effect, the cookies for FDT generation are not necessarily
the same type anymore. Therefore we cannot consult them for interrupt
pins and lines, but on ARM the supported devices are virtio ones only
and currently they all use the same pin and the same line. Let the VM
specify those as an intermediate solution.

Signed-off-by: Hannu Lyytinen <hannu.lyytinen@unikie.com>