### PR TITLE
trivial: Change log level for a print

### DIFF
--- a/libsel4vmmplatsupport/src/ioports.c
+++ b/libsel4vmmplatsupport/src/ioports.c
@@ -57,7 +57,7 @@ int emulate_io_handler(vmm_io_port_list_t *io_port, unsigned int port_no, bool i
         return -1;
     }
 
-    ZF_LOGI("exit io request: in %d  port no 0x%x (%s) size %d\n",
+    ZF_LOGD("exit io request: in %d  port no 0x%x (%s) size %d\n",
             is_in, port_no, vmm_debug_io_portno_desc(io_port, port_no), size);
 
     ioport_entry_t **res_port = search_port(io_port, port_no);


### PR DESCRIPTION
A lot of spam when log level is info making serial unusable.

Signed-off-by: Markku Ahvenjärvi <markkux@ssrc.tii.ae>